### PR TITLE
SLO support for PSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ changelog.sh
 .DS_Store
 .\#*
 \#*\#
+
+examples/django_example/onelogin

--- a/social/actions.py
+++ b/social/actions.py
@@ -27,6 +27,8 @@ def do_auth(backend, redirect_name='next'):
         )
     return backend.start()
 
+def do_slo(backend, redirect_name='next', *args, **kwargs):
+    return backend.end()
 
 def do_complete(backend, login, user=None, redirect_name='next',
                 *args, **kwargs):
@@ -93,6 +95,24 @@ def do_complete(backend, login, user=None, redirect_name='next',
     if backend.setting('SANITIZE_REDIRECTS', True):
         url = sanitize_redirect(backend.strategy.request_host(), url) or \
               backend.setting('LOGIN_REDIRECT_URL')
+    return backend.strategy.redirect(url)
+
+def do_complete_logout(backend, user=None, redirect_name='next',
+                *args, **kwargs):
+    data = backend.strategy.request_data()
+
+    is_authenticated = user_is_authenticated(user)
+    user = is_authenticated and user or None
+
+    partial = partial_pipeline_data(backend, user, *args, **kwargs)
+    if partial:
+        xargs, xkwargs = partial
+        response = backend.continue_pipeline(*xargs, **xkwargs)
+    else:
+        response = backend.complete_logout(user=user, *args, **kwargs)
+
+    url = backend.setting('LOGOUT_REDIRECT_URL', '/')
+
     return backend.strategy.redirect(url)
 
 

--- a/social/apps/django_app/default/fields.py
+++ b/social/apps/django_app/default/fields.py
@@ -11,7 +11,7 @@ except ImportError:
     from django.utils.encoding import smart_text
 
 
-class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
+class JSONField(models.TextField):
     """Simple JSON field that stores python structures as JSON strings
     on database.
     """

--- a/social/apps/django_app/urls.py
+++ b/social/apps/django_app/urls.py
@@ -9,7 +9,6 @@ except ImportError:
 
 from social.utils import setting_name
 
-
 extra = getattr(settings, setting_name('TRAILING_SLASH'), True) and '/' or ''
 
 
@@ -19,6 +18,10 @@ urlpatterns = patterns('social.apps.django_app.views',
         name='begin'),
     url(r'^complete/(?P<backend>[^/]+){0}$'.format(extra), 'complete',
         name='complete'),
+    url(r'^logout/(?P<backend>[^/]+){0}$'.format(extra), 'slo',
+        name='end'),
+    url(r'^complete_logout/(?P<backend>[^/]+){0}$'.format(extra), 'complete_logout',
+        name='complete_logout'),
     # disconnection
     url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), 'disconnect',
         name='disconnect'),

--- a/social/apps/django_app/views.py
+++ b/social/apps/django_app/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.cache import never_cache
 
 from social.utils import setting_name
-from social.actions import do_auth, do_complete, do_disconnect
+from social.actions import do_auth, do_slo, do_complete, do_complete_logout, do_disconnect
 from social.apps.django_app.utils import psa
 
 
@@ -18,6 +18,11 @@ NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
 def auth(request, backend):
     return do_auth(request.backend, redirect_name=REDIRECT_FIELD_NAME)
 
+@never_cache
+@psa('{0}:end'.format(NAMESPACE))
+def slo(request, backend):
+    return do_slo(request.backend, redirect_name=REDIRECT_FIELD_NAME)
+
 
 @never_cache
 @csrf_exempt
@@ -25,6 +30,14 @@ def auth(request, backend):
 def complete(request, backend, *args, **kwargs):
     """Authentication complete view"""
     return do_complete(request.backend, _do_login, request.user,
+                       redirect_name=REDIRECT_FIELD_NAME, *args, **kwargs)
+
+@never_cache
+@csrf_exempt
+@psa('{0}:complete_logout'.format(NAMESPACE))
+def complete_logout(request, backend, *args, **kwargs):
+    """Authentication complete view"""
+    return do_complete_logout(request.backend, request.user,
                        redirect_name=REDIRECT_FIELD_NAME, *args, **kwargs)
 
 

--- a/social/backends/base.py
+++ b/social/backends/base.py
@@ -37,8 +37,23 @@ class BaseAuth(object):
         else:
             return self.strategy.html(self.auth_html())
 
+    def end(self):
+        """Must return redirect SLO URL to auth provider"""
+        raise NotImplementedError('Implement in subclass')
+
     def complete(self, *args, **kwargs):
         return self.auth_complete(*args, **kwargs)
+
+    def complete_logout(self, *args, **kwargs):
+        pipeline = self.strategy.get_logout_pipeline()
+        if 'pipeline_index' in kwargs:
+            pipeline = pipeline[kwargs['pipeline_index']:]
+        kwargs['name'] = self.name
+        kwargs['user_storage'] = self.strategy.storage.user
+
+        something = self.logout_complete(*args, **kwargs)
+
+        return self.run_pipeline(pipeline, *args, **kwargs)
 
     def auth_url(self):
         """Must return redirect URL to auth provider"""
@@ -50,6 +65,10 @@ class BaseAuth(object):
 
     def auth_complete(self, *args, **kwargs):
         """Completes loging process, must return user instance"""
+        raise NotImplementedError('Implement in subclass')
+
+    def logout_complete(self, *args, **kwargs):
+        """Completes logout process, must return user instance"""
         raise NotImplementedError('Implement in subclass')
 
     def process_error(self, data):

--- a/social/backends/saml.py
+++ b/social/backends/saml.py
@@ -89,6 +89,11 @@ class SAMLIdentityProvider(object):
         return self.conf['url']
 
     @property
+    def slo_url(self):
+        """Get the SLO URL for this IdP"""
+        return self.conf['slo_url']
+
+    @property
     def x509cert(self):
         """X.509 Public Key Certificate for this IdP"""
         return self.conf['x509cert']
@@ -102,6 +107,10 @@ class SAMLIdentityProvider(object):
             'singleSignOnService': {
                 'url': self.sso_url,
                 # python-saml only supports Redirect
+                'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+            },
+            'singleLogoutService': {
+                'url': self.slo_url,
                 'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
             },
             'x509cert': self.x509cert,
@@ -121,6 +130,7 @@ class DummySAMLIdentityProvider(SAMLIdentityProvider):
             'dummy',
             entity_id='https://dummy.none/saml2',
             url='https://dummy.none/SSO',
+            slo_url='https://dummy.none/SLO',
             x509cert=''
         )
 
@@ -204,7 +214,7 @@ class SAMLAuth(BaseAuth):
                 'x509cert': self.setting('SP_PUBLIC_CERT'),
                 'privateKey': self.setting('SP_PRIVATE_KEY'),
             },
-            'strict': True,  # We must force strict mode - for security
+            'strict': self.setting('SP_SAML_RESTRICT_MODE', True),
         }
         config["security"].update(self.setting("SECURITY_CONFIG", {}))
         config["sp"].update(self.setting("SP_EXTRA", {}))
@@ -264,6 +274,16 @@ class SAMLAuth(BaseAuth):
         # URL.
         return auth.login(return_to=idp_name)
 
+    def logout_url(self):
+        """Get the URL for SLO"""
+        try:
+            idp_name = self.strategy.request_data()['idp']
+        except KeyError:
+            raise AuthMissingParameter(self, 'idp')
+        auth = self._create_saml_auth(idp=self.get_idp(idp_name))
+
+        return auth.logout(return_to=idp_name)
+
     def get_user_details(self, response):
         """Get user details like full name, email, etc. from the
         response - see auth_complete"""
@@ -307,6 +327,13 @@ class SAMLAuth(BaseAuth):
         kwargs.update({'response': response, 'backend': self})
         return self.strategy.authenticate(*args, **kwargs)
 
+    def logout_complete(self, *args, **kwargs):
+        idp_name = self.strategy.request_data()['RelayState']
+        idp = self.get_idp(idp_name)
+        auth = self._create_saml_auth(idp)
+        slo_url = auth.process_slo()
+        return slo_url
+
     def _check_entitlements(self, idp, attributes):
         """
         Additional verification of a SAML response before
@@ -321,3 +348,6 @@ class SAMLAuth(BaseAuth):
         continue.
         """
         pass
+
+    def end(self):
+        return self.strategy.redirect(self.logout_url())

--- a/social/pipeline/__init__.py
+++ b/social/pipeline/__init__.py
@@ -57,3 +57,5 @@ DEFAULT_DISCONNECT_PIPELINE = (
     # Removes the social associations.
     'social.pipeline.disconnect.disconnect'
 )
+
+DEFAULT_LOGOUT_PIPELINE = ()

--- a/social/pipeline/logout.py
+++ b/social/pipeline/logout.py
@@ -1,0 +1,1 @@
+# no default methods. available for override

--- a/social/strategies/base.py
+++ b/social/strategies/base.py
@@ -4,7 +4,7 @@ import hashlib
 
 from social.utils import setting_name, module_member
 from social.store import OpenIdStore, OpenIdSessionWrapper
-from social.pipeline import DEFAULT_AUTH_PIPELINE, DEFAULT_DISCONNECT_PIPELINE
+from social.pipeline import DEFAULT_AUTH_PIPELINE, DEFAULT_DISCONNECT_PIPELINE, DEFAULT_LOGOUT_PIPELINE
 from social.pipeline.utils import partial_from_session, partial_to_session
 
 
@@ -99,6 +99,9 @@ class BaseStrategy(object):
 
     def get_disconnect_pipeline(self):
         return self.setting('DISCONNECT_PIPELINE', DEFAULT_DISCONNECT_PIPELINE)
+
+    def get_logout_pipeline(self):
+        return self.setting('LOGOUT_PIPELINE', DEFAULT_LOGOUT_PIPELINE)
 
     def random_string(self, length=12, chars=ALLOWED_CHARS):
         # Implementation borrowed from django 1.4


### PR DESCRIPTION
This PR adds support for Single Log Out (SLO) to the SAML back end, on the python social auth package.

New settings: 
* LOGOUT_REDIRECT_URL (default='/')
* SP_SAML_RESTRICT_MODE (default=False) This settings allows to run the pipeline locally avoiding URLs matching, must be False for prod, because is super insecure.

New URLs:
* /logout
* /complete_logout

Also adds a new pipeline: `LOGOUT_PIPELINE`


John added: http://python-social-auth.readthedocs.io/en/latest/pipeline.html
_For anyone not already familiar with this_